### PR TITLE
feat(zshrc): adding autocomplete for zsh

### DIFF
--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -72,12 +72,12 @@ zstyle ':omz:update' mode auto      # update automatically without asking
 # Add wisely, as too many plugins slow down shell startup.
 plugins=(git iterm2 dotenv)
 
-# source $HOMEBREW_PREFIX/share/zsh-autocomplete/zsh-autocomplete.plugin.zsh
-# bindkey              '^I'         menu-complete
-# bindkey '$terminfo[kcbt]' reverse-menu-complete
-# bindkey "^[[1;2A" up-line-or-history    # Shift + Up Arrow
-# bindkey "^[[1;2B" down-line-or-history  # Shift + Down Arrow
-# zstyle ':autocomplete:*' delay 0.5  # seconds (float)
+source $HOMEBREW_PREFIX/share/zsh-autocomplete/zsh-autocomplete.plugin.zsh
+bindkey              '^I'         menu-complete
+bindkey '$terminfo[kcbt]' reverse-menu-complete
+bindkey "^[[1;2A" up-line-or-history    # Shift + Up Arrow
+bindkey "^[[1;2B" down-line-or-history  # Shift + Down Arrow
+zstyle ':autocomplete:*' delay 0.5  # seconds (float)
 
 source $ZSH/oh-my-zsh.sh
 

--- a/install_packages.sh
+++ b/install_packages.sh
@@ -25,7 +25,7 @@ packages=(
     mosh
     docker
     zsh
-#    zsh-autocomplete
+    zsh-autocomplete
     node
 #    terraform
     opentofu

--- a/install_packages.sh
+++ b/install_packages.sh
@@ -25,7 +25,7 @@ packages=(
     mosh
     docker
     zsh
-    zsh-autocomplete
+#    zsh-autocomplete
     node
 #    terraform
     opentofu


### PR DESCRIPTION
### TL;DR

Enable zsh-autocomplete plugin and configure key bindings

### What changed?

Uncommented the zsh-autocomplete configuration in `.zshrc`, which:
- Sources the zsh-autocomplete plugin
- Sets up tab completion with `menu-complete`
- Configures reverse menu completion with Shift+Tab
- Adds key bindings for Shift+Up and Shift+Down arrows for history navigation
- Sets autocomplete delay to 0.5 seconds

### How to test?

1. Source the updated `.zshrc` file: `source ~/.zshrc`
2. Test tab completion by typing a partial command and pressing Tab
3. Try Shift+Tab for reverse completion
4. Use Shift+Up/Down arrows to navigate through command history
5. Verify autocomplete suggestions appear after the configured delay

### Why make this change?

To enhance the shell experience with autocomplete functionality, making command-line navigation more efficient and user-friendly. The autocomplete plugin provides intelligent suggestions and the configured key bindings make it easier to navigate through options and command history.