### PR TITLE
fix: clone dotfiles to ~/.dotfiles to avoid cluttering ~/

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,7 +6,7 @@
 set -e
 
 DOTFILES_REPO="https://github.com/adityataps/dotfiles.git"
-DOTFILES_DIR="$HOME/dotfiles"
+DOTFILES_DIR="$HOME/.dotfiles"
 
 echo "==> Bootstrapping dotfiles"
 


### PR DESCRIPTION
## Summary
- Changes `DOTFILES_DIR` in `bootstrap.sh` from `$HOME/dotfiles` to `$HOME/.dotfiles`
- Keeps the cloned repo hidden from plain `ls ~/`, following the de facto dotfile community convention
- Symlinks are unaffected (`~/.zshrc → ~/.dotfiles/dotfiles/.zshrc`)

## Test plan
- [ ] Run bootstrap on a fresh machine (or VM) and confirm repo clones to `~/.dotfiles`
- [ ] Confirm dotfile symlinks resolve correctly after bootstrap
- [ ] Confirm `~/dotfiles` is not created

🤖 Generated with [Claude Code](https://claude.com/claude-code)